### PR TITLE
Add "notes" to metadata

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -2899,7 +2899,8 @@ class Spoiler(object):
                          'triforcepool': self.world.treasure_hunt_total,
                          'race': self.world.settings.world_rep['meta']['race'],
                          'code': {p: Settings.make_code(self.world, p) for p in range(1, self.world.players + 1)},
-                         'seed': self.world.seed
+                         'seed': self.world.seed,
+                         'notes': self.world.settings.world_rep['meta']['notes']
                          }
 
         for p in range(1, self.world.players + 1):
@@ -3045,6 +3046,8 @@ class Spoiler(object):
         with open(filename, 'w') as outfile:
             line_width = 35
             outfile.write('ALttP Overworld Randomizer  -  Seed: %s\n\n' % (self.world.seed))
+            if self.metadata['notes']:
+                outfile.write('Notes: %s\n' % ljust(self.world.settings.world_rep['meta']['notes']))
             for k,v in self.metadata["versions"].items():
                 outfile.write((k + ' Version:').ljust(line_width) + '%s\n' % v)
             outfile.write('Filling Algorithm:'.ljust(line_width) + '%s\n' % self.world.algorithm)

--- a/CLI.py
+++ b/CLI.py
@@ -354,7 +354,8 @@ def parse_settings():
         "outputpath": os.path.join("."),
         "saveonexit": "ask",
         "outputname": "",
-        "startinventoryarray": {}
+        "startinventoryarray": {},
+        "notes": ""
     }
 
     if sys.platform.lower().find("windows"):

--- a/Main.py
+++ b/Main.py
@@ -165,7 +165,7 @@ def main(args, seed=None, fish=None):
             world.player_names[player].append(name)
     logger.info('')
     world.settings = CustomSettings()
-    world.settings.create_from_world(world, args.race)
+    world.settings.create_from_world(world, args)
 
     outfilebase = f'OR_{args.outputname if args.outputname else world.seed}'
 

--- a/resources/app/cli/args.json
+++ b/resources/app/cli/args.json
@@ -575,5 +575,6 @@
     ]
   },
   "outputname": {},
-  "code": {}
+  "code": {},
+  "notes": {}
 }

--- a/source/classes/CustomSettings.py
+++ b/source/classes/CustomSettings.py
@@ -221,14 +221,15 @@ class CustomSettings(object):
             return self.file_source['drops']
         return None
 
-    def create_from_world(self, world, race):
+    def create_from_world(self, world, settings):
         self.player_range = range(1, world.players + 1)
         settings_dict, meta_dict = {}, {}
         self.world_rep['meta'] = meta_dict
         meta_dict['players'] = world.players
         meta_dict['algorithm'] = world.algorithm
         meta_dict['seed'] = world.seed
-        meta_dict['race'] = race
+        meta_dict['race'] = settings.race
+        meta_dict['notes'] = settings.notes
         self.world_rep['settings'] = settings_dict
         for p in self.player_range:
             settings_dict[p] = {}


### PR DESCRIPTION
Implement "notes" metadata and argument. This allows preset yamls to specify some general notes about the settings. Also usable from the CLI.