### PR TITLE
Account for failure to determine locale.

### DIFF
--- a/source/classes/BabelFish.py
+++ b/source/classes/BabelFish.py
@@ -5,6 +5,8 @@ import os
 class BabelFish():
 	def __init__(self,subpath=["resources","app","meta"],lang=None):
 		localization_string = locale.getdefaultlocale()[0] #get set localization
+		if localization_string is None:
+			localization_string = "en"
 		self.locale = localization_string[:2] if lang is None else lang #let caller override localization
 		self.langs = ["en"] #start with English
 		if(not self.locale == "en"): #add localization


### PR DESCRIPTION
`getdefaultlocale` is documented to return `None` if it can't determine the locale. I had this happen in game mode on Steam Deck.

The documentation also says that `getdefaultlocale` is deprecated, but switching to a different function didn't fix the problem I encountered.